### PR TITLE
Correct start_url path

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "/",
+  "start_url": "/wavepad/",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#000000",


### PR DESCRIPTION
Else, the start URL points to https://alexgibson.github.io/, which is not correct.
